### PR TITLE
Make work on CPU only (just set use_gpu to False in test_network.py)

### DIFF
--- a/models/dist_model.py
+++ b/models/dist_model.py
@@ -35,7 +35,10 @@ class DistModel(BaseModel):
         self.model_name = '%s [%s]'%(model,net)
         if(self.model == 'net-lin'): # pretrained net + linear layer
             self.net = networks.PNetLin(use_gpu=use_gpu,pnet_type=net,use_dropout=True)
-            self.net.load_state_dict(torch.load('./weights/%s.pth'%net))
+            kw = {}
+            if not use_gpu:
+                kw['map_location'] = 'cpu'
+            self.net.load_state_dict(torch.load('./weights/%s.pth'%net, **kw))
         elif(self.model=='net'): # pretrained network
             self.net = networks.PNet(use_gpu=use_gpu,pnet_type=net)
             self.is_fake_net = True

--- a/test_network.py
+++ b/test_network.py
@@ -1,20 +1,23 @@
+import sys; sys.path += ['models']
 import torch
 from util import util
 from models import dist_model as dm
 from IPython import embed
 
+use_gpu = True
+
 ## Initializing the model
 model = dm.DistModel()
 
 # Linearly calibrated models
-# model.initialize(model='net-lin',net='squeeze',use_gpu=True)
-model.initialize(model='net-lin',net='alex',use_gpu=True)
-# model.initialize(model='net-lin',net='vgg',use_gpu=True)
+# model.initialize(model='net-lin',net='squeeze',use_gpu=use_gpu)
+model.initialize(model='net-lin',net='alex',use_gpu=use_gpu)
+# model.initialize(model='net-lin',net='vgg',use_gpu=use_gpu)
 
 # Off-the-shelf uncalibrated networks
-# model.initialize(model='net',net='squeeze',use_gpu=True)
-# model.initialize(model='net',net='alex',use_gpu=True)
-# model.initialize(model='net',net='vgg',use_gpu=True)
+# model.initialize(model='net',net='squeeze',use_gpu=use_gpu)
+# model.initialize(model='net',net='alex',use_gpu=use_gpu)
+# model.initialize(model='net',net='vgg',use_gpu=use_gpu)
 
 # Low-level metrics
 # model.initialize(model='l2',colorspace='Lab')

--- a/util/util.py
+++ b/util/util.py
@@ -10,7 +10,6 @@ import matplotlib.pyplot as plt
 from scipy.ndimage.interpolation import zoom
 from skimage.measure import compare_ssim
 import torch
-import progressbar
 from IPython import embed
 import cv2
 from datetime import datetime


### PR DESCRIPTION
I made this run on CPU only, due to the new MacBook not having an Nvidia card. Just set use_gpu to False in test_network. I tested all the 6 networks in test_network on CPU: they all work.

I also removed the progressbar dependency: this module appears to not be used.