### PR TITLE
Add spatial option which returns a spatial map of the perceptual difference (shape height x width)

### DIFF
--- a/test_network.py
+++ b/test_network.py
@@ -5,7 +5,7 @@ from models import dist_model as dm
 from IPython import embed
 import numpy
 
-use_gpu = False         # Whether to use GPU
+use_gpu = True          # Whether to use GPU
 spatial = False         # Whether to return a spatial map of distance of size height x width
 
 ## Initializing the model

--- a/test_network.py
+++ b/test_network.py
@@ -3,21 +3,23 @@ import torch
 from util import util
 from models import dist_model as dm
 from IPython import embed
+import numpy
 
-use_gpu = True
+use_gpu = False         # Whether to use GPU
+spatial = False         # Whether to return a spatial map of distance of size height x width
 
 ## Initializing the model
 model = dm.DistModel()
 
 # Linearly calibrated models
-# model.initialize(model='net-lin',net='squeeze',use_gpu=use_gpu)
-model.initialize(model='net-lin',net='alex',use_gpu=use_gpu)
-# model.initialize(model='net-lin',net='vgg',use_gpu=use_gpu)
+#model.initialize(model='net-lin',net='squeeze',use_gpu=use_gpu,spatial=spatial)
+model.initialize(model='net-lin',net='alex',use_gpu=use_gpu,spatial=spatial)
+#model.initialize(model='net-lin',net='vgg',use_gpu=use_gpu,spatial=spatial)
 
 # Off-the-shelf uncalibrated networks
-# model.initialize(model='net',net='squeeze',use_gpu=use_gpu)
-# model.initialize(model='net',net='alex',use_gpu=use_gpu)
-# model.initialize(model='net',net='vgg',use_gpu=use_gpu)
+#model.initialize(model='net',net='squeeze',use_gpu=use_gpu)
+#model.initialize(model='net',net='alex',use_gpu=use_gpu)
+#model.initialize(model='net',net='vgg',use_gpu=use_gpu)
 
 # Low-level metrics
 # model.initialize(model='l2',colorspace='Lab')
@@ -33,6 +35,15 @@ dist = model.forward(dummy_im0,dummy_im1)
 ex_ref = util.im2tensor(util.load_image('./imgs/ex_ref.png'))
 ex_p0 = util.im2tensor(util.load_image('./imgs/ex_p0.png'))
 ex_p1 = util.im2tensor(util.load_image('./imgs/ex_p1.png'))
-ex_d0 = model.forward(ex_ref,ex_p0)[0]
-ex_d1 = model.forward(ex_ref,ex_p1)[0]
-print('Distances: (%.3f, %.3f)'%(ex_d0,ex_d1))
+ex_d0 = model.forward(ex_ref,ex_p0)
+ex_d1 = model.forward(ex_ref,ex_p1)
+if not spatial:
+    print('Distances: (%.6f, %.6f)'%(ex_d0, ex_d1))
+else:
+    print('Distances: (%.6f, %.6f)'%(ex_d0.mean(),ex_d1.mean()))            # The mean distance is the same as the non-spatial distance
+    
+    # Visualize a spatially-varying distance map
+    import pylab
+    pylab.imshow(ex_d0)
+    pylab.show()
+


### PR DESCRIPTION
This option is demonstrated in the test_network.py when spatial is set to True.

When the mean is taken of the spatial distance map, the resulting distance is the same as the scalar perceptual distance. However, the spatial distance map additionally allows one to visualize which spatial regions the network has determined are different.

The spatial distance map is created by using nearest neighbor upsampling on the individual layer responses. The upsampled size is the least common multiple of the associated layer sizes. This choice allows the mean of the spatial distance map to match the original scalar distance in the paper.