### PR TITLE
Add spatial option which returns a spatial map of the perceptual difference (an array with shape (height, width))

### DIFF
--- a/test_network.py
+++ b/test_network.py
@@ -3,10 +3,10 @@ import torch
 from util import util
 from models import dist_model as dm
 from IPython import embed
-import numpy
 
-use_gpu = True          # Whether to use GPU
-spatial = False         # Whether to return a spatial map of distance of size height x width
+use_gpu = False         # Whether to use GPU
+spatial = False         # Return a spatial map of perceptual distance.
+                        # Optional args spatial_shape and spatial_order control output shape and resampling filter: see DistModel.initialize() for details.
 
 ## Initializing the model
 model = dm.DistModel()
@@ -38,12 +38,11 @@ ex_p1 = util.im2tensor(util.load_image('./imgs/ex_p1.png'))
 ex_d0 = model.forward(ex_ref,ex_p0)
 ex_d1 = model.forward(ex_ref,ex_p1)
 if not spatial:
-    print('Distances: (%.6f, %.6f)'%(ex_d0, ex_d1))
+    print('Distances: (%.3f, %.3f)'%(ex_d0, ex_d1))
 else:
-    print('Distances: (%.6f, %.6f)'%(ex_d0.mean(),ex_d1.mean()))            # The mean distance is the same as the non-spatial distance
+    print('Distances: (%.3f, %.3f)'%(ex_d0.mean(),ex_d1.mean()))            # The mean distance is approximately the same as the non-spatial distance
     
-    # Visualize a spatially-varying distance map
+    # Visualize a spatially-varying distance map between ex_p0 and ex_ref
     import pylab
     pylab.imshow(ex_d0)
     pylab.show()
-

--- a/test_network.py
+++ b/test_network.py
@@ -5,7 +5,7 @@ from models import dist_model as dm
 from IPython import embed
 import numpy
 
-use_gpu = False         # Whether to use GPU
+use_gpu = True          # Whether to use GPU
 spatial = False         # Whether to return a spatial map of distance of size height x width
 
 ## Initializing the model

--- a/test_network.py
+++ b/test_network.py
@@ -3,21 +3,23 @@ import torch
 from util import util
 from models import dist_model as dm
 from IPython import embed
+import numpy
 
-use_gpu = True
+use_gpu = False         # Whether to use GPU
+spatial = False         # Whether to return a spatial map of distance of size height x width
 
 ## Initializing the model
 model = dm.DistModel()
 
 # Linearly calibrated models
-# model.initialize(model='net-lin',net='squeeze',use_gpu=use_gpu)
-model.initialize(model='net-lin',net='alex',use_gpu=use_gpu)
-# model.initialize(model='net-lin',net='vgg',use_gpu=use_gpu)
+#model.initialize(model='net-lin',net='squeeze',use_gpu=use_gpu,spatial=spatial)
+model.initialize(model='net-lin',net='alex',use_gpu=use_gpu,spatial=spatial)
+#model.initialize(model='net-lin',net='vgg',use_gpu=use_gpu,spatial=spatial)
 
 # Off-the-shelf uncalibrated networks
-# model.initialize(model='net',net='squeeze',use_gpu=use_gpu)
-# model.initialize(model='net',net='alex',use_gpu=use_gpu)
-# model.initialize(model='net',net='vgg',use_gpu=use_gpu)
+#model.initialize(model='net',net='squeeze',use_gpu=use_gpu)
+#model.initialize(model='net',net='alex',use_gpu=use_gpu)
+#model.initialize(model='net',net='vgg',use_gpu=use_gpu)
 
 # Low-level metrics
 # model.initialize(model='l2',colorspace='Lab')
@@ -33,6 +35,15 @@ dist = model.forward(dummy_im0,dummy_im1)
 ex_ref = util.im2tensor(util.load_image('./imgs/ex_ref.png'))
 ex_p0 = util.im2tensor(util.load_image('./imgs/ex_p0.png'))
 ex_p1 = util.im2tensor(util.load_image('./imgs/ex_p1.png'))
-ex_d0 = model.forward(ex_ref,ex_p0)[0]
-ex_d1 = model.forward(ex_ref,ex_p1)[0]
-print('Distances: (%.3f, %.3f)'%(ex_d0,ex_d1))
+ex_d0 = model.forward(ex_ref,ex_p0)
+ex_d1 = model.forward(ex_ref,ex_p1)
+if not spatial:
+    print('Distances: (%.6f, %.6f)'%(ex_d0, ex_d1))
+else:
+    print('Distances: (%.6f, %.6f)'%(ex_d0.mean(),ex_d1.mean()))            # The mean distance is the same as the non-spatial distance
+    
+    # Visualize a spatially-varying distance map
+    import pylab
+    pylab.imshow(ex_d0)
+    pylab.show()
+


### PR DESCRIPTION
The main change here is the spatial optional parameter of DistModel.initialize(), which if True causes spatial maps of perceptual distance to be returned by forward(). This is demonstrated in test_network.py.

Also, add to DistModel.initialize() optional arguments spatial_shape, spatial_order, and spatial_factor. These are documented in DistModel.initialize() docstring, and referred to in the example program test_network.py. These variables control spatial output shape (spatial_shape), upsampling filter order (spatial_order), and spatial_factor determines a default shape if one is not specified by multiplier factor of the max size of the CNN layer spatial extents.