### PR TITLE
cover use case of .jpeg files

### DIFF
--- a/lpips/__init__.py
+++ b/lpips/__init__.py
@@ -105,7 +105,7 @@ def load_image(path):
         import rawpy
         with rawpy.imread(path) as raw:
             img = raw.postprocess()
-    elif(path[-3:]=='bmp' or path[-3:]=='jpg' or path[-3:]=='png'):
+    elif(path[-3:]=='bmp' or path[-3:]=='jpg' or path[-3:]=='png' or path[-4:]=='jpeg'):
         import cv2
         return cv2.imread(path)[:,:,::-1]
     else:


### PR DESCRIPTION
A student of mine found a small issue where files with the extension of `.jpeg` throws incorrect errors. This covers that issue with an addition to the `elif` statement.