### PR TITLE
Fix reference to skimage dependency

### DIFF
--- a/lpips/__init__.py
+++ b/lpips/__init__.py
@@ -21,8 +21,8 @@ def psnr(p0, p1, peak=255.):
     return 10*np.log10(peak**2/np.mean((1.*p0-1.*p1)**2))
 
 def dssim(p0, p1, range=255.):
-    from skimage.measure import compare_ssim
-    return (1 - compare_ssim(p0, p1, data_range=range, multichannel=True)) / 2.
+    from skimage.metrics import structural_similarity
+    return (1 - structural_similarity(p0, p1, data_range=range, multichannel=True)) / 2.
 
 def tensor2np(tensor_obj):
     # change dimension of a tensor object into a numpy array


### PR DESCRIPTION
this function has been removed in latest skimage.

`from skimage.measure import compare_ssim`

Change to `skimage.metrics.structural_similarity`

see https://github.com/williamfzc/stagesepx/issues/150 for similar issue