### PR TITLE
Fixed an Error when training L2 and SSIM models

### DIFF
--- a/lpips/lpips.py
+++ b/lpips/lpips.py
@@ -216,7 +216,7 @@ class L2(FakeNet):
             ret_var = Variable( torch.Tensor((value,) ) )
             if(self.use_gpu):
                 ret_var = ret_var.cuda()
-            return ret_var
+            return ret_var.reshape(-1,1,1,1)
 
 class DSSIM(FakeNet):
 
@@ -231,7 +231,7 @@ class DSSIM(FakeNet):
         ret_var = Variable( torch.Tensor((value,) ) )
         if(self.use_gpu):
             ret_var = ret_var.cuda()
-        return ret_var
+        return ret_var.reshape(-1,1,1,1)
 
 def print_network(net):
     num_params = 0


### PR DESCRIPTION
I use translation software to write down the following information. If you have any questions, please point them out and I will explain them in more detail.

### what I did
Fixed a BUG that caused Error when training L2 and SSIM models

### the Error is
RuntimeError: Expected 3D (unbatched) or 4D (batched) input to conv2d, but got input of size: [5]

![image](https://user-images.githubusercontent.com/34237511/211301556-73c77313-82d1-41ee-95f7-2c78bbfc5853.png)

### my env
I deployed LPIPS on the latest version of pytorch (and other packages).And I met this BUG.So I'm not sure if this BUG exists on the deployment of the original version.

### how did this BUG appear
The error report occurred after the model forward function, when the value was introduced into the rank model forward function. After debug, I found that, unlike the LPIPS model, the size of the forward output Tensor of these two models is [1], not expected [1,1,1,1].

Combined with the prompt of error report, I think this should be the key to solving BUG.I reshape the Tensor and it works now.