### PR TITLE
Update lpips.py

### DIFF
--- a/lpips/lpips.py
+++ b/lpips/lpips.py
@@ -139,9 +139,9 @@ class LPIPS(nn.Module):
             val += res[l]
         
         if(retPerLayer):
-            return (val, res)
+            return (val.squeeze(), res)
         else:
-            return val
+            return val.squeeze()
 
 
 class ScalingLayer(nn.Module):


### PR DESCRIPTION
When I using the lpips.LPIPS(net='vgg'), I found that the output would be the shape like [[[[0.3333]]]], which lead a bad using experience and the result could not be used in the last loss combination operation. However, add squeeze to delete the "[]" automatically could solve the problem mentioned above.