### PR TITLE
Fixed smoothing issue with interpolating on PIL image when loading 2AFC images

### DIFF
--- a/data/dataset/twoafc_dataset.py
+++ b/data/dataset/twoafc_dataset.py
@@ -27,10 +27,10 @@ class TwoAFCDataset(BaseDataset):
         self.p1_paths = make_dataset(self.dir_p1)
         self.p1_paths = sorted(self.p1_paths)
 
-        transform_list = []
+        transform_list = [transforms.ToTensor()]
         transform_list.append(transforms.Resize(load_size))
-        transform_list += [transforms.ToTensor(),
-            transforms.Normalize((0.5, 0.5, 0.5),(0.5, 0.5, 0.5))]
+        transform_list.append(
+            transforms.Normalize((0.5, 0.5, 0.5),(0.5, 0.5, 0.5)))
 
         self.transform = transforms.Compose(transform_list)
 


### PR DESCRIPTION
There is an issue when calling `torchvision.transforms.Resize` on PIL images where antialiasing occurs. If you call `torchvision.transforms.ToTensor()` before resizing this issue is fixed.

I think this is a recent issue but it is worth checking whether this occurred during the perceptual experiments, as there is significant smoothing when resizing the BAPPS images (which are saved as 256x256 images with repeating blocks of 4x4) to 64x64.