### PR TITLE
Fix normalize instability crash

### DIFF
--- a/lpips/__init__.py
+++ b/lpips/__init__.py
@@ -10,8 +10,8 @@ import torch
 from lpips.trainer import *
 from lpips.lpips import *
 
-def normalize_tensor(in_feat,eps=1e-10):
-    norm_factor = torch.sqrt(torch.sum(in_feat**2,dim=1,keepdim=True))
+def normalize_tensor(in_feat,eps=1e-6):
+    norm_factor = torch.sqrt(eps+torch.sum(in_feat**2,dim=1,keepdim=True))
     return in_feat/(norm_factor+eps)
 
 def l2(p0, p1, range=255.):


### PR DESCRIPTION
Change eps to 1.0e-6 for bf16 stability and so sqrt is not given a negative number.

Before fix
- Training runs randomly crash because radicand gets close to zero and is rounded to a small negative number
- eps is rounded to 0 in mixed precision training runs
After fix
- Denominator stays positive
- Radicand stays non-negative